### PR TITLE
Fix for "pull-to-refresh" demo in Android stock browser.

### DIFF
--- a/demo/dom-list.html
+++ b/demo/dom-list.html
@@ -164,16 +164,16 @@
 				return;
 			}
 			
-			scroller.doTouchStart(e.touches, e.timeStamp);
+			scroller.doTouchStart(e.touches, +e.timeStamp);
 			e.preventDefault();
 		}, false);
 
 		document.addEventListener("touchmove", function(e) {
-			scroller.doTouchMove(e.touches, e.timeStamp);
+			scroller.doTouchMove(e.touches, +e.timeStamp);
 		}, false);
 
 		document.addEventListener("touchend", function(e) {
-			scroller.doTouchEnd(e.timeStamp);
+			scroller.doTouchEnd(+e.timeStamp);
 		}, false);
 		
 	} else {


### PR DESCRIPTION
It appears that in Android stock browser, the timeStamp property of touch events is a Date rather than a Number. "+" based type casting fixes the problem.

(might affect other demos, I haven't checked)
