### PR TITLE
bouncing property fix

### DIFF
--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -1172,7 +1172,7 @@ var Scroller;
 
 			if (!self.options.bouncing) {
 
-				var scrollLeftFixed = Math.max(Math.min(self.__maxScrollLeft, scrollLeft), 0);
+				var scrollLeftFixed = Math.max(Math.min(self.__maxDecelerationScrollLeft, scrollLeft), self.__minDecelerationScrollLeft);
 				if (scrollLeftFixed !== scrollLeft) {
 					scrollLeft = scrollLeftFixed;
 					self.__decelerationVelocityX = 0;


### PR DESCRIPTION
Fix that stops a page swipe (paging-x) from flowing to the last page when swiping left and flowing to the first page when swiping right when the bouncing property is set to false.
