### PR TITLE
bug fix for browsers that don't support HTML5 dataset attribute

### DIFF
--- a/src/EasyScroller.js
+++ b/src/EasyScroller.js
@@ -185,8 +185,8 @@ document.addEventListener("DOMContentLoaded", function() {
 	for (var i = 0; i < elements.length; i++) {
 
 		element = elements[i];
-		var scrollable = element.dataset.scrollable;
-		var zoomable = element.dataset.zoomable || '';
+		var scrollable = element.attributes.getNamedItem('data-scrollable') ? element.attributes.getNamedItem('data-scrollable').value : null;
+		var zoomable = element.attributes.getNamedItem('data-zoomable') ? element.attributes.getNamedItem('data-zoomable').value : '';
 		var zoomOptions = zoomable.split('-');
 		var minZoom = zoomOptions.length > 1 && parseFloat(zoomOptions[0]);
 		var maxZoom = zoomOptions.length > 1 && parseFloat(zoomOptions[1]);


### PR DESCRIPTION
easy scroller wasn't working in android 2.3.5 (and other non-HTML5 devices). this fixes that.