### PR TITLE
Add an optional scrollingComplete callback that is fired on the later of touch end or deceleration end

### DIFF
--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -15,7 +15,8 @@
 var Scroller;
 
 (function() {
-	
+	var NOOP = function(){};
+
 	/**
 	 * A pure logic 'component' for 'virtual' scrolling/zooming.
 	 */
@@ -24,7 +25,7 @@ var Scroller;
 		this.__callback = callback;
 
 		this.options = {
-			
+
 			/** Enable scrolling on x-axis */
 			scrollingX: true,
 
@@ -58,8 +59,14 @@ var Scroller;
 			/** Maximum zoom level */
 			maxZoom: 3,
 
-            /** Multiply or decrease scrolling speed **/
-            speedMultiplier: 1
+			/** Multiply or decrease scrolling speed **/
+			speedMultiplier: 1,
+
+			/** Callback that is fired on the later of touch end or deceleration end,
+				provided that another scrolling action has not begun. Used to know
+				when to fade out a scrollbar. */
+			scrollingComplete: NOOP
+
 		};
 
 		for (var key in options) {
@@ -67,11 +74,11 @@ var Scroller;
 		}
 
 	};
-	
-	
+
+
 	// Easing Equations (c) 2003 Robert Penner, all rights reserved.
 	// Open source under the BSD License.
-	
+
 	/**
 	 * @param pos {Number} position between 0 (start of effect) and 1 (end of effect)
 	**/
@@ -89,8 +96,8 @@ var Scroller;
 
 		return 0.5 * (Math.pow((pos - 2), 3) + 2);
 	};
-	
-	
+
+
 	var members = {
 
 		/*
@@ -104,6 +111,9 @@ var Scroller;
 
 		/** {Boolean} Whether a touch event sequence is in progress */
 		__isTracking: false,
+
+		/** {Boolean} Whether a deceleration animation went to completion. */
+		__didDecelerationComplete: false,
 
 		/**
 		 * {Boolean} Whether a gesture zoom/rotate event is in progress. Activates when
@@ -163,16 +173,16 @@ var Scroller;
 
 		/** {Integer} Height to assign to refresh area */
 		__refreshHeight: null,
-		
+
 		/** {Boolean} Whether the refresh process is enabled when the event is released now */
 		__refreshActive: false,
-		
+
 		/** {Function} Callback to execute on activation. This is for signalling the user about a refresh is about to happen when he release */
 		__refreshActivate: null,
 
 		/** {Function} Callback to execute on deactivation. This is for signalling the user about the refresh being cancelled */
 		__refreshDeactivate: null,
-		
+
 		/** {Function} Callback to execute to start the actual refresh. Call {@link #refreshFinish} when done */
 		__refreshStart: null,
 
@@ -216,7 +226,7 @@ var Scroller;
 
 		/** {Date} Timestamp of last move of finger. Used to limit tracking range for deceleration speed. */
 		__lastTouchMove: null,
-		
+
 		/** {Array} List of positions, uses three indexes for each state: left, top, timestamp */
 		__positions: null,
 
@@ -290,7 +300,7 @@ var Scroller;
 
 			// Refresh scroll position
 			self.scrollTo(self.__scrollLeft, self.__scrollTop, true);
-			
+
 		},
 
 
@@ -346,22 +356,22 @@ var Scroller;
 			self.__refreshStart = startCallback;
 
 		},
-		
-		
+
+
 		/**
-		 * Signalizes that pull-to-refresh is finished. 
+		 * Signalizes that pull-to-refresh is finished.
 		 */
 		finishPullToRefresh: function() {
-			
+
 			var self = this;
-			
+
 			self.__refreshActive = false;
 			if (self.__refreshDeactivate) {
 				self.__refreshDeactivate();
 			}
-			
+
 			self.scrollTo(self.__scrollLeft, self.__scrollTop, true);
-			
+
 		},
 
 
@@ -381,22 +391,22 @@ var Scroller;
 			};
 
 		},
-		
-		
+
+
 		/**
 		 * Returns the maximum scroll values
 		 *
 		 * @return {Map} `left` and `top` maximum scroll values
 		 */
 		getScrollMax: function() {
-			
+
 			var self = this;
-			
+
 			return {
 				left: self.__maxScrollLeft,
 				top: self.__maxScrollTop
 			};
-			
+
 		},
 
 
@@ -492,31 +502,31 @@ var Scroller;
 		scrollTo: function(left, top, animate, zoom) {
 
 			var self = this;
-			
+
 			// Stop deceleration
 			if (self.__isDecelerating) {
 				core.effect.Animate.stop(self.__isDecelerating);
 				self.__isDecelerating = false;
 			}
-			
+
 			// Correct coordinates based on new zoom level
 			if (zoom != null && zoom !== self.__zoomLevel) {
-				
+
 				if (!self.options.zooming) {
 					throw new Error("Zooming is not enabled!");
 				}
-				
+
 				left *= zoom;
 				top *= zoom;
-				
+
 				// Recompute maximum values while temporary tweaking maximum scroll ranges
 				self.__computeScrollMax(zoom);
-				
+
 			} else {
-				
+
 				// Keep zoom when not defined
 				zoom = self.__zoomLevel;
-				
+
 			}
 
 			if (!self.options.scrollingX) {
@@ -556,7 +566,7 @@ var Scroller;
 			if (left === self.__scrollLeft && top === self.__scrollTop) {
 				animate = false;
 			}
-			
+
 			// Publish new values
 			self.__publish(left, top, zoom, animate);
 
@@ -618,19 +628,24 @@ var Scroller;
 			if (typeof timeStamp !== "number") {
 				throw new Error("Invalid timestamp value: " + timeStamp);
 			}
-			
+
 			var self = this;
+
+			// Reset interruptedAnimation flag
+			self.__interruptedAnimation = true;
 
 			// Stop deceleration
 			if (self.__isDecelerating) {
 				core.effect.Animate.stop(self.__isDecelerating);
 				self.__isDecelerating = false;
+				self.__interruptedAnimation = true;
 			}
 
 			// Stop animation
 			if (self.__isAnimating) {
 				core.effect.Animate.stop(self.__isAnimating);
 				self.__isAnimating = false;
+				self.__interruptedAnimation = true;
 			}
 
 			// Use center point when dealing with two fingers
@@ -668,6 +683,9 @@ var Scroller;
 			// Reset tracking flag
 			self.__isTracking = true;
 
+			// Reset deceleration complete flag
+			self.__didDecelerationComplete = false;
+
 			// Dragging starts directly with two fingers, otherwise lazy with an offset
 			self.__isDragging = !isSingleTouch;
 
@@ -696,15 +714,15 @@ var Scroller;
 			if (typeof timeStamp !== "number") {
 				throw new Error("Invalid timestamp value: " + timeStamp);
 			}
-			
+
 			var self = this;
 
 			// Ignore event when tracking is not enabled (event might be outside of element)
 			if (!self.__isTracking) {
 				return;
 			}
-			
-			
+
+
 			var currentTouchLeft, currentTouchTop;
 
 			// Compute move based around of center of fingers
@@ -747,7 +765,7 @@ var Scroller;
 						// Compute relative event position to container
 						var currentTouchLeftRel = currentTouchLeft - self.__clientLeft;
 						var currentTouchTopRel = currentTouchTop - self.__clientTop;
-						
+
 						// Recompute left and top coordinates based on new zoom level
 						scrollLeft = ((currentTouchLeftRel + scrollLeft) * level / oldLevel) - currentTouchLeftRel;
 						scrollTop = ((currentTouchTopRel + scrollTop) * level / oldLevel) - currentTouchTopRel;
@@ -794,7 +812,7 @@ var Scroller;
 						if (self.options.bouncing) {
 
 							scrollTop += (moveY / 2 * this.options.speedMultiplier);
-							
+
 							// Support pull-to-refresh (only when only y is scrollable)
 							if (!self.__enableScrollX && self.__refreshHeight != null) {
 
@@ -826,12 +844,12 @@ var Scroller;
 						}
 					}
 				}
-				
+
 				// Keep list from growing infinitely (holding min 10, max 20 measure points)
 				if (positions.length > 60) {
 					positions.splice(0, 30);
 				}
-				
+
 				// Track scroll movement for decleration
 				positions.push(scrollLeft, scrollTop, timeStamp);
 
@@ -849,10 +867,13 @@ var Scroller;
 
 				self.__enableScrollX = self.options.scrollingX && distanceX >= minimumTrackingForScroll;
 				self.__enableScrollY = self.options.scrollingY && distanceY >= minimumTrackingForScroll;
-				
+
 				positions.push(self.__scrollLeft, self.__scrollTop, timeStamp);
 
 				self.__isDragging = (self.__enableScrollX || self.__enableScrollY) && (distanceX >= minimumTrackingForDrag || distanceY >= minimumTrackingForDrag);
+				if (self.__isDragging) {
+					self.__interruptedAnimation = false;
+				}
 
 			}
 
@@ -869,14 +890,14 @@ var Scroller;
 		 * Touch end handler for scrolling support
 		 */
 		doTouchEnd: function(timeStamp) {
-			
+
 			if (timeStamp instanceof Date) {
 				timeStamp = timeStamp.valueOf();
 			}
 			if (typeof timeStamp !== "number") {
 				throw new Error("Invalid timestamp value: " + timeStamp);
 			}
-			
+
 			var self = this;
 
 			// Ignore event when tracking is not enabled (no touchstart event on element)
@@ -884,7 +905,7 @@ var Scroller;
 			if (!self.__isTracking) {
 				return;
 			}
-			
+
 			// Not touching anymore (when two finger hit the screen there are two touch end events)
 			self.__isTracking = false;
 
@@ -903,21 +924,21 @@ var Scroller;
 					var positions = self.__positions;
 					var endPos = positions.length - 1;
 					var startPos = endPos;
-					
+
 					// Move pointer to position measured 100ms ago
 					for (var i = endPos; i > 0 && positions[i] > (self.__lastTouchMove - 100); i -= 3) {
 						startPos = i;
 					}
-					
-					// If start and stop position is identical in a 100ms timeframe, 
+
+					// If start and stop position is identical in a 100ms timeframe,
 					// we cannot compute any useful deceleration.
 					if (startPos !== endPos) {
-						
+
 						// Compute relative movement between these two points
 						var timeOffset = positions[endPos] - positions[startPos];
 						var movedLeft = self.__scrollLeft - positions[startPos - 2];
 						var movedTop = self.__scrollTop - positions[startPos - 1];
-						
+
 						// Based on 50ms compute the movement to apply for each render step
 						self.__decelerationVelocityX = movedLeft / timeOffset * (1000 / 60);
 						self.__decelerationVelocityY = movedTop / timeOffset * (1000 / 60);
@@ -927,16 +948,18 @@ var Scroller;
 
 						// Verify that we have enough velocity to start deceleration
 						if (Math.abs(self.__decelerationVelocityX) > minVelocityToStartDeceleration || Math.abs(self.__decelerationVelocityY) > minVelocityToStartDeceleration) {
-							
+
 							// Deactivate pull-to-refresh when decelerating
 							if (!self.__refreshActive) {
-
 								self.__startDeceleration(timeStamp);
-
 							}
 						}
+					} else {
+						self.options.scrollingComplete();
 					}
-				}
+				} else if ((timeStamp - self.__lastTouchMove) > 100) {
+					self.options.scrollingComplete();
+	 			}
 			}
 
 			// If this was a slower move it is per default non decelerated, but this
@@ -947,31 +970,34 @@ var Scroller;
 			if (!self.__isDecelerating) {
 
 				if (self.__refreshActive && self.__refreshStart) {
-					
+
 					// Use publish instead of scrollTo to allow scrolling to out of boundary position
 					// We don't need to normalize scrollLeft, zoomLevel, etc. here because we only y-scrolling when pull-to-refresh is enabled
 					self.__publish(self.__scrollLeft, -self.__refreshHeight, self.__zoomLevel, true);
-					
+
 					if (self.__refreshStart) {
 						self.__refreshStart();
 					}
-					
+
 				} else {
-					
+
+					if (self.__interruptedAnimation || self.__isDragging) {
+						self.options.scrollingComplete();
+					}
 					self.scrollTo(self.__scrollLeft, self.__scrollTop, true, self.__zoomLevel);
-					
+
 					// Directly signalize deactivation (nothing todo on refresh?)
 					if (self.__refreshActive) {
-						
+
 						self.__refreshActive = false;
 						if (self.__refreshDeactivate) {
 							self.__refreshDeactivate();
 						}
-						
+
 					}
 				}
 			}
-			
+
 			// Fully cleanup list
 			self.__positions.length = 0;
 
@@ -995,7 +1021,7 @@ var Scroller;
 		__publish: function(left, top, zoom, animate) {
 
 			var self = this;
-			
+
 			// Remember whether we had an animation, then we try to continue based on the current "drive" of the animation
 			var wasAnimating = self.__isAnimating;
 			if (wasAnimating) {
@@ -1042,12 +1068,15 @@ var Scroller;
 					if (animationId === self.__isAnimating) {
 						self.__isAnimating = false;
 					}
-					
+					if (self.__didDecelerationComplete || wasFinished) {
+						self.options.scrollingComplete();
+					}
+
 					if (self.options.zooming) {
 						self.__computeScrollMax();
 					}
 				};
-				
+
 				// When continuing based on previous animation we choose an ease-out animation instead of ease-in-out
 				self.__isAnimating = core.effect.Animate.start(step, verify, completed, self.options.animationDuration, wasAnimating ? easeOutCubic : easeInOutCubic);
 
@@ -1076,14 +1105,14 @@ var Scroller;
 		__computeScrollMax: function(zoomLevel) {
 
 			var self = this;
-			
+
 			if (zoomLevel == null) {
 				zoomLevel = self.__zoomLevel;
 			}
 
 			self.__maxScrollLeft = Math.max((self.__contentWidth * zoomLevel) - self.__clientWidth, 0);
 			self.__maxScrollTop = Math.max((self.__contentHeight * zoomLevel) - self.__clientHeight, 0);
-			
+
 		},
 
 
@@ -1136,11 +1165,18 @@ var Scroller;
 			// Detect whether it's still worth to continue animating steps
 			// If we are already slow enough to not being user perceivable anymore, we stop the whole process here.
 			var verify = function() {
-				return Math.abs(self.__decelerationVelocityX) >= minVelocityToKeepDecelerating || Math.abs(self.__decelerationVelocityY) >= minVelocityToKeepDecelerating;
+				var shouldContinue = Math.abs(self.__decelerationVelocityX) >= minVelocityToKeepDecelerating || Math.abs(self.__decelerationVelocityY) >= minVelocityToKeepDecelerating;
+				if (!shouldContinue) {
+					self.__didDecelerationComplete = true;
+				}
+				return shouldContinue;
 			};
 
 			var completed = function(renderedFramesPerSecond, animationId, wasFinished) {
 				self.__isDecelerating = false;
+				if (self.__didDecelerationComplete) {
+					self.options.scrollingComplete();
+				}
 
 				// Animate to grid when snapping is active, otherwise just fix out-of-boundary positions
 				self.scrollTo(self.__scrollLeft, self.__scrollTop, self.options.snapping);
@@ -1271,10 +1307,10 @@ var Scroller;
 			}
 		}
 	};
-	
+
 	// Copy over members to prototype
 	for (var key in members) {
 		Scroller.prototype[key] = members[key];
 	}
-		
+
 })();


### PR DESCRIPTION
Add an optional scrollingComplete callback that is fired on the later of touch end or deceleration end, provided that another scrolling action has not begun. It can be used to know when to fade out a scrollbar.
