### PR TITLE
Rename core global to zynga so that core-js shim can be used

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -32,14 +32,14 @@
 	var counter = 1;
 
 	// Create namespaces
-	if (!global.core) {
-		global.core = { effect : {} };
+	if (!global.zynga) {
+		global.zynga = { effect : {} };
 
-	} else if (!core.effect) {
-		core.effect = {};
+	} else if (!zynga.effect) {
+		zynga.effect = {};
 	}
 
-	core.effect.Animate = {
+	zynga.effect.Animate = {
 
 		/**
 		 * A requestAnimationFrame wrapper / polyfill.
@@ -221,7 +221,7 @@
 					completedCallback && completedCallback(desiredFrames - (dropCounter / ((now - start) / millisecondsPerSecond)), id, percent === 1 || duration == null);
 				} else if (render) {
 					lastFrame = now;
-					core.effect.Animate.requestAnimationFrame(step, root);
+					zynga.effect.Animate.requestAnimationFrame(step, root);
 				}
 			};
 
@@ -229,7 +229,7 @@
 			running[id] = true;
 
 			// Init first step
-			core.effect.Animate.requestAnimationFrame(step, root);
+			zynga.effect.Animate.requestAnimationFrame(step, root);
 
 			// Return unique animation ID
 			return id;

--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -455,7 +455,7 @@ var Scroller;
 
 			// Stop deceleration
 			if (self.__isDecelerating) {
-				core.effect.Animate.stop(self.__isDecelerating);
+				zynga.effect.Animate.stop(self.__isDecelerating);
 				self.__isDecelerating = false;
 			}
 
@@ -532,7 +532,7 @@ var Scroller;
 
 			// Stop deceleration
 			if (self.__isDecelerating) {
-				core.effect.Animate.stop(self.__isDecelerating);
+				zynga.effect.Animate.stop(self.__isDecelerating);
 				self.__isDecelerating = false;
 			}
 
@@ -665,14 +665,14 @@ var Scroller;
 
 			// Stop deceleration
 			if (self.__isDecelerating) {
-				core.effect.Animate.stop(self.__isDecelerating);
+				zynga.effect.Animate.stop(self.__isDecelerating);
 				self.__isDecelerating = false;
 				self.__interruptedAnimation = true;
 			}
 
 			// Stop animation
 			if (self.__isAnimating) {
-				core.effect.Animate.stop(self.__isAnimating);
+				zynga.effect.Animate.stop(self.__isAnimating);
 				self.__isAnimating = false;
 				self.__interruptedAnimation = true;
 			}
@@ -1056,7 +1056,7 @@ var Scroller;
 			// Remember whether we had an animation, then we try to continue based on the current "drive" of the animation
 			var wasAnimating = self.__isAnimating;
 			if (wasAnimating) {
-				core.effect.Animate.stop(wasAnimating);
+				zynga.effect.Animate.stop(wasAnimating);
 				self.__isAnimating = false;
 			}
 
@@ -1113,7 +1113,7 @@ var Scroller;
 				};
 
 				// When continuing based on previous animation we choose an ease-out animation instead of ease-in-out
-				self.__isAnimating = core.effect.Animate.start(step, verify, completed, self.options.animationDuration, wasAnimating ? easeOutCubic : easeInOutCubic);
+				self.__isAnimating = zynga.effect.Animate.start(step, verify, completed, self.options.animationDuration, wasAnimating ? easeOutCubic : easeInOutCubic);
 
 			} else {
 
@@ -1222,7 +1222,7 @@ var Scroller;
 			};
 
 			// Start animation and switch on flag
-			self.__isDecelerating = core.effect.Animate.start(step, verify, completed);
+			self.__isDecelerating = zynga.effect.Animate.start(step, verify, completed);
 
 		},
 


### PR DESCRIPTION
We ran into an unfortunate issue where this library is incompatible with the babel transpiler when including the widely used babel-polyfill script, which defines the `window.core` variable for [internal use](https://github.com/zloirock/core-js/blob/master/build/index.js#L85).   In order to mitigate I have renamed the `core` global to `zynga`.